### PR TITLE
build(deps): bump guzzlehttp/guzzle from 7.2.0 to 7.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,14 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The Laravel Framework.",
-    "keywords": ["framework", "laravel"],
+    "keywords": [
+        "framework",
+        "laravel"
+    ],
     "license": "MIT",
     "require": {
         "php": "^8.0.2",
-        "guzzlehttp/guzzle": "^7.2",
+        "guzzlehttp/guzzle": "^7.4.3",
         "laravel/framework": "^9.11",
         "laravel/sanctum": "^2.14.1",
         "laravel/tinker": "^2.7"


### PR DESCRIPTION
This PR updates the composer dependencies and fixes potential security issues.

Resolve: https://github.com/hasinhayder/hydra/issues/8