### PR TITLE
Security: prevent updating email_verified_at field by the user role

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -99,7 +99,6 @@ class UserController extends Controller {
         $user->name = $request->name ?? $user->name;
         $user->email = $request->email ?? $user->email;
         $user->password = $request->password ? Hash::make($request->password) : $user->password;
-        $user->email_verified_at = $request->email_verified_at ?? $user->email_verified_at;
 
         //check if the logged in user is updating it's own record
 
@@ -107,6 +106,7 @@ class UserController extends Controller {
         if ($loggedInUser->id == $user->id) {
             $user->update();
         } elseif ($loggedInUser->tokenCan('admin') || $loggedInUser->tokenCan('super-admin')) {
+            $user->email_verified_at = $request->email_verified_at ?? $user->email_verified_at;
             $user->update();
         } else {
             throw new MissingAbilityException('Not Authorized');


### PR DESCRIPTION
The ordinary user can update the email_verified_at which mustn't be modified by him, as it depends on a unique URL sent to his email to make sure that he owns the email address.