### PR TITLE
feat: force api json

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Hydra is a zero-config API boilerplate with Laravel Sanctum and comes with excel
     - [Default Admin Username and Password](#default-admin-username-and-password)
     - [Default Role for New Users](#default-role-for-new-users)
     - [Single Session or Multiple Session](#single-session-or-multiple-session)
-    - [Add `Accept: application/json` Header In Your API Calls (Important)](#add-accept-applicationjson-header-in-your-api-calls-important)
     - [Logging](#logging)
     - [Code Formatting](#code-formatting)
   - [Tutorial](#tutorial)
@@ -789,24 +788,6 @@ Hydra doesn't invalidate the previously issued access tokens when a user authent
 
 This ENV variable is configured in in `config/hydra.php`, and then used in `app/Http/Controllers/UserController.php`
 
-### Add `Accept: application/json` Header In Your API Calls (Important)
-
-This is very important. To properly receive JSON responses, add the following header to your API requests.
-
-```shell
-Accept: application/json
-```
-
-For example, if you are using `curl` you can make a call like this. 
-
-```shell
-curl --request GET \
-  --url http://localhost:8000/hydra/version \
-  --header 'Accept: application/json' \
-  --header 'Content-Type: application/x-www-form-urlencoded' \
-  --data =
-```
-
 ### Logging
 
 Hydra comes with an excellent logger to log request headers, parameters and response to help debugging and inspecting API calls. All you have to do is wrap the route with 'hydra.log' middleware, as shown below 
@@ -901,7 +882,6 @@ To create a new user, you can place a curl request or use tools like Postman, In
 ```shell
 curl --request POST \
   --url http://localhost:8000/api/users \
-  --header 'Accept: application/json' \
   --header 'Content-Type: multipart/form-data; boundary=---011000010111000001101001' \
   --form 'name=Hydra User' \
   --form email=user@hydra.project \
@@ -913,7 +893,6 @@ Great! Now we have our users. Let's login as this new user using curl (You can u
 ```shell
 curl --request POST \
   --url http://localhost:8000/api/login \
-  --header 'Accept: aplication/json' \
   --header 'Content-Type: application/json' \
   --data '{
     "email": "user@hydra.project",
@@ -934,7 +913,6 @@ Now let's test our protected route. Add this bearer token in your PostMan/Insomn
 ```shell
 curl --request GET \
   --url http://localhost:8000/api/greet \
-  --header 'Accept: application/json' \
   --header 'Authorization: Bearer 5|gbiWdd7yJFYiTIgoK1jK3C7HZJtJUK1PnBIToBLN'
 ```
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends HttpKernel {
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\JsonResponseMiddleware::class,
     ];
 
     /**

--- a/app/Http/Middleware/JsonResponseMiddleware.php
+++ b/app/Http/Middleware/JsonResponseMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class JsonResponseMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $request->headers->set('Accept', 'application/json');
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Since the template is made for api's, I forced the `accept: application/json` header on all endpoints in the `kernel`. This means that it is no longer necessary to put this header in every time you make a request. I have also updated the documentation.